### PR TITLE
make recordOrigin field of customer service controllable

### DIFF
--- a/Resources/definition/Customer.json
+++ b/Resources/definition/Customer.json
@@ -2,19 +2,20 @@
     "id": "Customer",
     "description": "Simple Customer Service",
     "service": {
-        "baseController": "\\Graviton\\PersonBundle\\Controller\\AbstractCustomerController",
         "fixtureOrder": 45,
-        "parent": "graviton.person.controller.abstractcustomer",
         "readOnly": false,
+        "recordOriginModifiable": false,
         "routerBase": "/person/customer/",
         "fixtures": [
             {
                 "id": "100",
-                "name": "Acme Corps."
+                "name": "Acme Corps.",
+                "recordOrigin": "core"
             },
             {
                 "id": "101",
-                "name": "Widgets4U gmbh"
+                "name": "Widgets4U gmbh",
+                "recordOrigin": "otherCore"
             },
             {
                 "id": "102",


### PR DESCRIPTION
remove baseController and parent attributes, because they are not longer used.

New is the recordOriginModifiable attribute in the service definition. We can control with this flag whether a record with the recordOrign field can be modified. For example: modifications with values like 'core' are not allowed.