### PR TITLE
EVO-2695 added a field definition containing the constraint Choice

### DIFF
--- a/Resources/definition/ShowCase.json
+++ b/Resources/definition/ShowCase.json
@@ -298,6 +298,21 @@
                 "type": "class:GravitonDyn\\CustomerBundle\\Document\\Customer[]",
                 "title": "customers",
                 "description": "nested list of customers"
+            },
+            {
+                "name": "choices",
+                "type": "string",
+                "title": "Choices",
+                "required": true,
+                "description": "A field containing an ENum values restricted by constraints",
+                "constraints": [
+                    {
+                        "name": "Choice",
+                        "options": [
+                            {"name": "choices", "value": "<|>|=|>=|<=|<>"}
+                        ]
+                    }
+                ]
             }
         ]
     }


### PR DESCRIPTION
In Order to test a field with the Choice constraint, the definition for ShowCase in ShowCase.json is modified.
This is working together with the pull request #360 in libgraviton/graviton:
https://github.com/libgraviton/graviton/pull/360
and this commit to the branch feature/evo-2695-choices on libgraviton/graviton:
https://github.com/libgraviton/graviton/commit/b6176f08be0f321156cbd14c281dab112cb74a4b