### PR TITLE
EVO-2695 bugfix in ShowCase data

### DIFF
--- a/Resources/definition/ShowCase.json
+++ b/Resources/definition/ShowCase.json
@@ -112,7 +112,8 @@
                         "customerNumber": "1234",
                         "$ref": "http://localhost/core/app/admin"
                     }
-                ]
+                ],
+                "choices": ">="
             },
             {
                 "id": "600",
@@ -163,7 +164,8 @@
                     "booleanField": true,
                     "dateField": "2012-12-24T14:15:55Z",
                     "someFloatyDouble": 458.114
-                }
+                },
+                "choices": "<>"
             }
         ]
     },


### PR DESCRIPTION
The field "choices" was defined as required but not delivered by the fixtures. 
This leads to failing tests!
Fixed with this pull request.